### PR TITLE
Support subqueries within joins

### DIFF
--- a/squel.d.ts
+++ b/squel.d.ts
@@ -8,10 +8,10 @@ interface SqlSelect {
   fields(fields: Object | any[]): SqlSelect
   from(name: string, alias?: string): SqlSelect
   join(name: string, alias?: string, condition?: string | any): SqlSelect
-  left_join(name: string, alias?: string, condition?: string | any): SqlSelect
-  right_join(name: string, alias?: string, condition?: string | any): SqlSelect
-  outer_join(name: string, alias?: string, condition?: string | any): SqlSelect
-  cross_join(name: string, alias?: string, condition?: string | any): SqlSelect
+  left_join(name: string | SqlSelect, alias?: string, condition?: string | any): SqlSelect
+  right_join(name: string | SqlSelect, alias?: string, condition?: string | any): SqlSelect
+  outer_join(name: string | SqlSelect, alias?: string, condition?: string | any): SqlSelect
+  cross_join(name: string | SqlSelect, alias?: string, condition?: string | any): SqlSelect
   where(condition: string | Expression, ...args: any[]): SqlSelect
   order(field: string, direction?: boolean, ...args: any[]): SqlSelect
   group(field: string): SqlSelect


### PR DESCRIPTION
Support typecheck in situation where `join` contains query generated by Squel:

```
squel.select()
  .from('marks', 'm')
  .join( squel.select().from('students'), 's', 's.id = m.id' )
  .toString()
```